### PR TITLE
mainブランチへのMergeでもCIが回るようにした

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@
 # run tests and linters.
 name: "CI"
 on:
+  push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 jobs:


### PR DESCRIPTION
`main`ブランチと作業ブランチで差異が生じる場合もあるため、
```yml
  push:
    branches: [ "main" ]
```
このコードを復活させた。