### PR TITLE
HTML上でh1タグを使っても大文字の太文字にならない理由を解明した

### DIFF
--- a/app/controllers/sandbox_controller.rb
+++ b/app/controllers/sandbox_controller.rb
@@ -1,0 +1,4 @@
+class SandboxController < ApplicationController
+  def h1test
+  end
+end

--- a/app/helpers/sandbox_helper.rb
+++ b/app/helpers/sandbox_helper.rb
@@ -1,0 +1,2 @@
+module SandboxHelper
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,7 +6,8 @@ html
     meta[name="viewport" content="width=device-width,initial-scale=1"]
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag 'application', 'data-turbo-track': 'reload'
+    / ここでスタイルシートの設定が当たっているから、HTMLを書いただけではHTML構造のデフォルトのCSSが反映されない
+    / = stylesheet_link_tag 'application', 'data-turbo-track': 'reload'
     = javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true
   body
     p.notice

--- a/app/views/sandbox/h1test.html.slim
+++ b/app/views/sandbox/h1test.html.slim
@@ -1,0 +1,4 @@
+/ stylesheet_link_tagをコメントアウトしているので、h1が大きく表示される
+h1 Sandbox#h1test
+/ Tailwindのこの書き方は、stylesheet_link_tagを有効にしないと反映されない
+p.bg-red-500 Find me in app/views/sandbox/h1test.html.slim

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'sandbox/h1test'
   get 'terms_of_service', to: 'top#terms_of_service'
   get 'privacy_policy', to: 'top#privacy_policy'
   devise_for :users


### PR DESCRIPTION
## 問題

本来ならこうなって欲しいのに、
![image](https://user-images.githubusercontent.com/93074851/224907817-b930729d-a740-4d37-9fbf-ad2fcb1e5a94.png)


このようになっている理由を調査した。
![image](https://user-images.githubusercontent.com/93074851/224908144-98d3318c-c30a-4825-bff6-ff0370c998b5.png)


## 調査結果

CSSを`layouts/application.html.slim`
```
    = stylesheet_link_tag 'application', 'data-turbo-track': 'reload'
```

ここで設定しているのが理由だった。

ここで、CSS設定をまっさらな状態にリセットして、なおかつTailwind CSSを使えるようにしている。

CSSファイルを何も設定していない状態だと、簡易的なCSSが当たるようになっている（リセットはされていない）。
そのため、普通のHTMLファイルだと`h1`タグが太文字の大文字になる。

```slim
h1 Sandbox#h1test
p.bg-red-500 Find me in app/views/sandbox/h1test.html.slim
```

そのため、上のコードは次のスクリーンショットのようになる。

### stylesheet_link_tagの行をコメントアウトする
![image](https://user-images.githubusercontent.com/93074851/224907817-b930729d-a740-4d37-9fbf-ad2fcb1e5a94.png)

### stylesheet_link_tagの行をコメントアウトしない
![image](https://user-images.githubusercontent.com/93074851/224908183-dddcdf2f-ff12-489e-aa9f-b1d01d3a2507.png)

## 結論
h1タグの文章が大文字の太文字になっていなくても、問題ない（リセットされているだけ）。

自分でTailwindを書いて、CSSを当ててあげて、読みやすくしていく必要がある。

ref: [とほほのリセットCSS入門 - とほほのWWW入門](https://www.tohoho-web.com/ex/reset-css.html)

つまり、リセットCSSが当たっているような状態だから、h1タグが大文字の太文字になっていなかった。