### PR TITLE
tsconfig.jsonのreactをreact-jsxに書き換えた

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     /* Language and Environment */
     "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    "jsx": "react",                                      /* Specify what JSX code is generated. */
+    "jsx": "react-jsx",                                      /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */


### PR DESCRIPTION
React17以降の新しい変換方式であり、こちらのほうが速度が速いため、`react-jsx`へと設定を変えた。

- [Rails 7 で React & TypeScript を導入する方法（tsx, esbuild, jsbundling-rails） - LEFログ：学習記録ノート](https://lef237.hatenablog.com/entry/2023/02/21/113432)

上の記事の追記欄（2023-03-18）に詳細を書きました。