### PR TITLE
resizeの方法を修正した

### DIFF
--- a/app/views/books/_book.html.slim
+++ b/app/views/books/_book.html.slim
@@ -1,8 +1,9 @@
 div id="#{dom_id book}"
   p
     strong Image:
-    / [200, (200 * Math.sqrt(2)).round] でも良い。一般的な本のサイズは横＊ルート2
-    =< image_tag book.avatar.variant(resize_and_pad: [200, 283]) if book.avatar.attached?
+    / 一般的な本のサイズは横＊ルート2。本の縦横比はCSSのほうで調整する。object-fit
+    / resize_to_limitを使うと、長い方の幅を300に合わせてくれるので、CSSで扱いやすく、縦横比も元のままで、なおかつ余計な空白も入らない。小さい画像の場合に、幅に合わせて拡大してくれるresize_to_fitのほうが良い気もするが、CSSで調整すれば良さそう。
+    =< image_tag book.avatar.variant(resize_to_limit: [700, 700]) if book.avatar.attached?
   p
     strong Title:
     =< book.title

--- a/app/views/books/_book.html.slim
+++ b/app/views/books/_book.html.slim
@@ -1,8 +1,7 @@
 div id="#{dom_id book}"
   p
     strong Image:
-    / 一般的な本のサイズは横＊ルート2。本の縦横比はCSSのほうで調整する。object-fit
-    / resize_to_limitを使うと、長い方の幅を300に合わせてくれるので、CSSで扱いやすく、縦横比も元のままで、なおかつ余計な空白も入らない。小さい画像の場合に、幅に合わせて拡大してくれるresize_to_fitのほうが良い気もするが、CSSで調整すれば良さそう。
+    / 一般的な本のサイズは横＊ルート2。本の縦横比はCSSのほうで調整する。object-fit containが良さそう。
     =< image_tag book.avatar.variant(resize_to_limit: [700, 700]) if book.avatar.attached?
   p
     strong Title:

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -5,4 +5,5 @@ p MyID: #{@user.id}
 p MyName: #{@user.name}
 p MyPage: #{@user.profile_url}
 
-= image_tag @user.avatar.variant(resize_to_fill: [200, 200]) if @user.avatar.attached?
+/ 後でCSSで調整する必要がある。object-fitのfillとか
+= image_tag @user.avatar.variant(resize_to_fit: [500, 500]) if @user.avatar.attached?


### PR DESCRIPTION
後でCSSで調整しやすいように修正した。

[object-fit - CSS: カスケーディングスタイルシート | MDN](https://developer.mozilla.org/ja/docs/Web/CSS/object-fit)

`object-fit`の`contain`や`fit`を使える。

Viewファイルのほうで画像を小さく切り取ってしまうと、画質が悪くなってしまうし、CSSで調整がしにくくなってしまう。