### PR TITLE
Reactのエンドポイントの処理を書き換えて、連番でなくても重複が無ければ表示されるようにした

### DIFF
--- a/app/javascript/MountComponents.tsx
+++ b/app/javascript/MountComponents.tsx
@@ -5,14 +5,29 @@ import Mount from "./Mount";
 const MountComponents = (
   component: unknown,
   divName: string,
-  numberOfComponents: number
+  divElements:  NodeListOf<HTMLDivElement>
 ) => {
-  const names = Array.from(
-    { length: numberOfComponents },
-    (_, index) => `${divName}${index + 1}`
-  );
+  // const names = Array.from(
+  //   { length: numberOfComponents },
+  //   (_, index) => `${divName}${index + 1}`
+  // );
+  console.log(divElements)
 
-  names.forEach((name) => {
+  const elements = [];
+
+  for (let i = 0; i < divElements.length; i++) {
+    if (divElements[i].id.includes(divName)) {
+      elements.push(divElements[i]);
+    }
+  }
+
+  console.log(elements);
+
+  const divNames = Array.from(elements).map((div) => div.id);
+
+  console.log(divNames)
+
+  divNames.forEach((name) => {
     Mount(component, name);
   });
 };

--- a/app/javascript/MountComponents.tsx
+++ b/app/javascript/MountComponents.tsx
@@ -5,14 +5,8 @@ import Mount from "./Mount";
 const MountComponents = (
   component: unknown,
   divName: string,
-  divElements:  NodeListOf<HTMLDivElement>
+  divElements: NodeListOf<HTMLDivElement>
 ) => {
-  // const names = Array.from(
-  //   { length: numberOfComponents },
-  //   (_, index) => `${divName}${index + 1}`
-  // );
-  console.log(divElements)
-
   const elements = [];
 
   for (let i = 0; i < divElements.length; i++) {
@@ -21,11 +15,7 @@ const MountComponents = (
     }
   }
 
-  console.log(elements);
-
   const divNames = Array.from(elements).map((div) => div.id);
-
-  console.log(divNames)
 
   divNames.forEach((name) => {
     Mount(component, name);

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -2,16 +2,12 @@
 import "@hotwired/turbo-rails";
 import "./controllers";
 
-import Mount from "./Mount";
 import MountComponents from "./MountComponents";
-import { getDivIds, getMaxId } from "./divUtil";
 import Hello from "./components/Hello";
 import Hey from "./components/Hey";
 import Hola from "./components/Hola";
 
 const divElements = document.querySelectorAll("div");
-// console.log(divElements)
-// const divIds = getDivIds(divElements);
 
 MountComponents(Hello, "hello", divElements);
 MountComponents(Hey, "hey", divElements);

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -10,8 +10,9 @@ import Hey from "./components/Hey";
 import Hola from "./components/Hola";
 
 const divElements = document.querySelectorAll("div");
-const divIds = getDivIds(divElements);
+// console.log(divElements)
+// const divIds = getDivIds(divElements);
 
-Mount(Hello, "hello");
-Mount(Hey, "hey");
-MountComponents(Hola, "hola", getMaxId("hola", divIds));
+MountComponents(Hello, "hello", divElements);
+MountComponents(Hey, "hey", divElements);
+MountComponents(Hola, "hola", divElements);


### PR DESCRIPTION
以前の状態では、必ずdivのidが`hoge1`から始まる連番になっている必要があり、Viewファイルを書くのが大変だった。

しかし、このPull Requestにより、`div`のIDの文字列が被っていなければ表示されるようになったので、一つのViewファイルで複数のReactコンポーネントを簡単に表示できるようになった。

具体的には、`kaminari`のようなgemを使うと、例えば１ページ目の表示数が`10`だとすると、`.each.with_index(1)`を使ったとしても、２ページ目のdivのidが`hoge11`から始まってしまい、そのページでは`1`からのスタートでは無くなってしまうため、Reactが表示されなくなってしまう恐れがあった。

今回の改善により、仮に`hoge11`から始まったとしても、問題なく表示されるようになった。重複が無く、なおかつエンドポイント側で指定された文字列が入っていればOKだからである。