### PR TITLE
ユーザーのアカウントに対する権限を変更した

### DIFF
--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -52,6 +52,7 @@ class QuotesController < ApplicationController
   end
 
   # DELETE /quotes/1 or /quotes/1.json
+  # 書籍ページに戻るようにする
   def destroy
     @quote.destroy
     respond_to do |format|

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -51,8 +51,4 @@
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
 <%= link_to "Back", :back %>


### PR DESCRIPTION
## アカウント削除は不可にした

Coquote（共同引用）される場合に、アカウントが削除されてしまうと、既存のデータが消えてしまって困るため。

user.rbが次のようになっている。
``` rb
has_many :quotes, dependent: :destroy
```
quote.rbが次のようになっている。
```rb
has_many :child_quotes, class_name: 'Quote', foreign_key: 'source_quote_id', inverse_of: :source_quote, dependent: :restrict_with_exception
```
そのためUser→Quote→ChildQuoteの順番で連結しているとき（そのユーザーの引用が共同引用されているとき）に、アカウント削除しようとすると、 `ActiveRecord::DeleteRestrictionError`が出るようになっている。

つまり、共同引用されていなければ、アカウントを削除することはできるが、それでも一度登録された有益な引用も消えてしまう恐れがある。

両者とも`dependent: :destroy`を使う方法もあるが、基本的に引用は消えないようにしたいため、このPull Requestのような形にすることに決めた。