### PR TITLE
Turbo Drive（Turbolinks）を無効にして、Turbo（Hotwire）とReactを同時に使えるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,10 +21,10 @@ gem 'puma', '~> 5.0'
 gem 'jsbundling-rails'
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-# gem 'turbo-rails'
+gem 'turbo-rails'
 
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
-# gem 'stimulus-rails'
+gem 'stimulus-rails'
 
 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
 gem 'cssbundling-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,10 +296,16 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    stimulus-rails (1.2.1)
+      railties (>= 6.0.0)
     temple (0.8.2)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.2)
+    turbo-rails (1.4.0)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -350,6 +356,8 @@ DEPENDENCIES
   slim-rails
   slim_lint
   sprockets-rails
+  stimulus-rails
+  turbo-rails
   tzinfo-data
   web-console
   webdrivers

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -3,7 +3,6 @@ import "@hotwired/turbo-rails";
 import "./controllers";
 import { Turbo } from "@hotwired/turbo-rails";
 
-// ReactとHotwireを同時に使えるようにするため、TurboDrive（TruboLinks）の機能だけを無効にしている
 Turbo.session.drive = false;
 
 import MountComponents from "./MountComponents";

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -1,8 +1,9 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails";
 import "./controllers";
-import { Turbo } from "@hotwired/turbo-rails"
+import { Turbo } from "@hotwired/turbo-rails";
 
+// ReactとHotwireを同時に使えるようにするため、TurboDrive（TruboLinks）の機能だけを無効にしている
 Turbo.session.drive = false;
 
 import MountComponents from "./MountComponents";

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -1,6 +1,9 @@
 // Entry point for the build script in your package.json
-// import "@hotwired/turbo-rails";
-// import "./controllers";
+import "@hotwired/turbo-rails";
+import "./controllers";
+import { Turbo } from "@hotwired/turbo-rails"
+
+Turbo.session.drive = false;
 
 import MountComponents from "./MountComponents";
 import Hello from "./components/Hello";

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -5,7 +5,7 @@ p style="color: green" = notice
 - if current_user
   div
     = link_to "Edit this book", edit_book_path(@book)
-    = button_to "Destroy this book", @book, method: :delete, form: { data: { turbo_confirm: "削除してよろしいですか？" } }
+    = button_to "Destroy this book", @book, method: :delete, form: { data: { turbo: true, turbo_confirm: "削除してよろしいですか？" } }
 
 div
   = link_to "Back to books", books_path

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,8 +6,8 @@ html
     meta[name="viewport" content="width=device-width,initial-scale=1"]
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag 'application'
-    = javascript_include_tag 'application', defer: true
+    = stylesheet_link_tag 'application', 'data-turbo-track': 'reload'
+    = javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true
   body
     p.notice
       = notice

--- a/app/views/quotes/show.html.slim
+++ b/app/views/quotes/show.html.slim
@@ -5,7 +5,6 @@ p style="color: green" = notice
 - if @quote.user == current_user
   div
     = link_to "Edit this quote", edit_quote_path(@quote)
-    / TurboRailsではなく、Reactで確認ダイアログを出すように設定する必要がある。
-    = button_to "Destroy this quote", @quote, method: :delete, form: { data: { turbo_confirm: "削除してよろしいですか？" } }
+    = button_to "Destroy this quote", @quote, method: :delete, form: { data: { turbo: true, turbo_confirm: "削除してよろしいですか？" } }
 div
   = link_to "Back to quotes", quotes_path


### PR DESCRIPTION
## 経緯
- #75 

上の #75 のPull Requestにおいて、Turboの機能を無効化することでTurbolinksも無効化して、Reactを表示させていた。

しかし、この方法だとTurboが完全に使えなくなってしまうため、例えば削除時の確認ダイアログまで表示されなくなってしまい、簡単なJavaScriptの操作であってもReactで書くことになってしまっていた。

そのため、「簡単な処理はHotwireでおこなって、複雑な処理はReactでおこなう。」という目標を達成するため、このPull Requestにおいては両者を同時に使えるようにした。

## 詳細
Rails 7 のおいては、`Turbolinks`は`Turbo Drive`という名前になっていた。このTurbo Driveの機能だけを無効化すれば、画面遷移時に通常の読み込み方法になるので、無事にReactが表示されるようになった。

Turboを使いたい部分に関してのみ、View側で`turbo: true`の設定を個別にしてあげれば、そこだけTurboが有効になるので確認ダイアログも表示されるようになった。

詳しくは、下記の参考URL２つを読むと、詳細について理解できる。

## 参考URL
- [Turbo Drive とは何か？](https://zenn.dev/takeyuwebinc/articles/8ebe80bf442dc2)
- [Turbo Drive｜猫でもわかるHotwire入門 Turbo編](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/turbo-drive)