### PR TITLE
OGP画像へのパスを相対パスから絶対パスに変更した

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
       'og:type' => 'website',
       'og:description' => content_for?(:description) ? content_for(:description) : '未知の書籍と出会う切っ掛けとして、色んな本の引用を閲覧・紹介することができます！ぜひ、色んな引用をクリックして、お気に入りの本を見つけてみましょう',
       'og:url' => request.original_url,
-      'og:image' => asset_path('quotelistogp.png')
+      'og:image' => asset_url('quotelistogp.png')
     }
   end
 
@@ -17,7 +17,7 @@ module ApplicationHelper
       'twitter:site' => '@lef237',
       'twitter:title' => content_for?(:title) ? content_for(:title) : '引用箱 QuoteList',
       'twitter:description' => content_for?(:description) ? content_for(:description) : '未知の書籍と出会う切っ掛けとして、色んな本の引用を閲覧・紹介することができます！ぜひ、色んな引用をクリックして、お気に入りの本を見つけてみましょう',
-      'twitter:image' => asset_path('quotelistogp.png')
+      'twitter:image' => asset_url('quotelistogp.png')
     }
   end
 end


### PR DESCRIPTION
相対パスだと、サイト側がうまくOGP画像を読み取ってくれない。

そのため、`asset_path`を`asset_url`へとすることで、絶対パスへと変更した。

デバッグはFacebookのこのツールを利用した。

- [シェアデバッガー - Meta for Developers](https://developers.facebook.com/tools/debug/)

参考になった記事はこちら。

- [【HTML】OGPが反映されない時の落とし穴｜スタッフブログ｜株式会社インソースマーケティングデザイン](https://insource-mkd.co.jp/staff-blog/10962/)