### PR TITLE
content_tagのdoをやめて第2引数を明示した

### DIFF
--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -63,9 +63,9 @@ div class="theme-cupcake container mx-auto px-4"
                 - number_coquoted = quote.child_quotes.length + 1
                 - if current_user
                   - already_coquoted = current_user.quotes.find_by(source_quote_id: quote.id).present?
-                  = content_tag :div, id: "coquotebutton#{index}", data: { quoteId: quote.id, isCoquoted: already_coquoted, numberCoquoted: number_coquoted }.to_json, class: 'mt-2' do
+                  = content_tag :div, nil, id: "coquotebutton#{index}", data: { quoteId: quote.id, isCoquoted: already_coquoted, numberCoquoted: number_coquoted }.to_json, class: 'mt-2'
                 - else
-                  = content_tag :div, id: "guestcoquotebutton#{index}", data: { quoteId: quote.id, numberCoquoted: number_coquoted }.to_json, class: 'mt-2' do
+                  = content_tag :div, nil, id: "guestcoquotebutton#{index}", data: { quoteId: quote.id, numberCoquoted: number_coquoted }.to_json, class: 'mt-2'
                 p.text-center
                   = link_to "この引用を表示する", coquote_users_quote_path(quote), class: 'btn btn-sm btn-outline btn-rounded'
             .text-center.mt-8.mb-6.text-xl

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -36,9 +36,9 @@ div class="theme-cupcake container mx-auto px-4 max-w-3xl"
             - number_coquoted = quote.child_quotes.length + 1
             - if current_user
               - already_coquoted = current_user.quotes.find_by(source_quote_id: quote.id).present?
-              = content_tag :div, id: "coquotebutton#{index}", data: { quoteId: quote.id, isCoquoted: already_coquoted, numberCoquoted: number_coquoted }.to_json, class: 'mt-2' do
+              = content_tag :div, nil, id: "coquotebutton#{index}", data: { quoteId: quote.id, isCoquoted: already_coquoted, numberCoquoted: number_coquoted }.to_json, class: 'mt-2'
             - else
-              = content_tag :div, id: "guestcoquotebutton#{index}", data: { quoteId: quote.id, numberCoquoted: number_coquoted }.to_json, class: 'mt-2' do
+              = content_tag :div, nil, id: "guestcoquotebutton#{index}", data: { quoteId: quote.id, numberCoquoted: number_coquoted }.to_json, class: 'mt-2'
             p.text-center.mb-4
               = link_to "この引用を表示する", coquote_users_quote_path(quote), class: 'btn btn-sm btn-outline btn-rounded'
 

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -16,6 +16,6 @@ header class="bg-white shadow-md px-4 py-2 relative w-full z-10"
           = f.text_field :keyword, placeholder: '著者名 or 書籍名', class: 'input input-xs input-bordered'
           = f.submit "検索", class: "btn btn-xs bg-gray-700 hover:bg-gray-800 text-white ml-2"
         - if current_user
-          = content_tag :div, id: "headerbutton", data: { isLogin: true, userId: current_user.id }.to_json, class: "mr-2" do
+          = content_tag :div, nil, id: "headerbutton", data: { isLogin: true, userId: current_user.id }.to_json, class: "mr-2"
         - else
-          = content_tag :div, id: "headerbutton", data: { isLogin: false, userId: nil }.to_json, class: "mr-2" do
+          = content_tag :div, nil, id: "headerbutton", data: { isLogin: false, userId: nil }.to_json, class: "mr-2"

--- a/app/views/quotes/index.html.slim
+++ b/app/views/quotes/index.html.slim
@@ -18,9 +18,9 @@ body class="text-gray-800 font-sans"
           - number_coquoted = quote.child_quotes.length + 1
           - if current_user
             - already_coquoted = current_user.quotes.find_by(source_quote_id: quote.id).present?
-            = content_tag :div, id: "coquotebutton#{index}", data: { quoteId: quote.id, isCoquoted: already_coquoted, numberCoquoted: number_coquoted }.to_json do
+            = content_tag :div, nil, id: "coquotebutton#{index}", data: { quoteId: quote.id, isCoquoted: already_coquoted, numberCoquoted: number_coquoted }.to_json
           - else
-            = content_tag :div, id: "guestcoquotebutton#{index}", data: { quoteId: quote.id, numberCoquoted: number_coquoted }.to_json do
+            = content_tag :div, nil, id: "guestcoquotebutton#{index}", data: { quoteId: quote.id, numberCoquoted: number_coquoted }.to_json
           p.text-center
             = link_to "この引用を表示する", quote, class: 'btn btn-sm btn-outline btn-rounded'
           br

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -46,9 +46,9 @@ div class="theme-cupcake container mx-auto px-4"
                 - number_coquoted = quote.child_quotes.length + 1
                 - if current_user
                   - already_coquoted = current_user.quotes.find_by(source_quote_id: quote.id).present?
-                  = content_tag :div, id: "coquotebutton#{index}", data: { quoteId: quote.id, isCoquoted: already_coquoted, numberCoquoted: number_coquoted }.to_json do
+                  = content_tag :div, nil, id: "coquotebutton#{index}", data: { quoteId: quote.id, isCoquoted: already_coquoted, numberCoquoted: number_coquoted }.to_json
                 - else
-                  = content_tag :div, id: "guestcoquotebutton#{index}", data: { quoteId: quote.id, numberCoquoted: number_coquoted }.to_json do
+                  = content_tag :div, nil, id: "guestcoquotebutton#{index}", data: { quoteId: quote.id, numberCoquoted: number_coquoted }.to_json
                 p class="mt-2 text-center"
                   = link_to "この引用を表示する", coquote_users_quote_path(quote), class: 'btn btn-sm btn-outline btn-rounded'
             .text-center.mt-8.mb-6.text-xl


### PR DESCRIPTION
## Issue

- #161 

## 概要

Viewファイルの`content_tag`の末尾についていた`do`をやめて、第2引数を`nil`として明示した。

これによってhamlを読むときの可読性を高めた。
